### PR TITLE
Bug 1163084 - Releng work for dummy apk

### DIFF
--- a/mozconfigs/mozconfig1.json
+++ b/mozconfigs/mozconfig1.json
@@ -1,0 +1,3 @@
+{
+    "gecko_path": "mobile/android/config/mozconfigs/public-partner/distribution_sample/mozconfig1"
+}


### PR DESCRIPTION
this adds a mozconfig manifest that points to a soon to be in-gecko-tree mozconfig.

currently this mozconfig1 will be equivalent to: https://dxr.mozilla.org/mozilla-central/source/mobile/android/config/mozconfigs/android-api-11/nightly
